### PR TITLE
Change the order of attrs in products to_a

### DIFF
--- a/csv.rb
+++ b/csv.rb
@@ -15,7 +15,7 @@ class Product
   end
 
   def to_a
-    [ @id, @name, @price, @category ]
+    [ @name, @price, @category, @id ]
   end
 end
 

--- a/csv.rb
+++ b/csv.rb
@@ -32,7 +32,7 @@ class ProductRepository
 
     def find id
       csv = CSV.read(file_location, col_sep: "|")
-      record = csv.to_a.find { |row| row[0].to_i == id}
+      record = csv.to_a.find { |row| row[-1].to_i == id}
       record ? Product.new(*record) : nil
     end
 


### PR DESCRIPTION
With the previous order in to_a whenever an array is created with the "all" method in ProductRepository the order of the attrs in the array's objects is mixed
